### PR TITLE
Allow SSH setup for Minecraft instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ Notice: all our images are based on Debian 10, and its Scaleway ID is `cc9188b3-
 
 ##### `minecraft` image
 
-The `redcraft-minecraft` image installs [rcsm](https://github.com/redcraft-org/redcraft_server_management) and you'll need to copy `rcsm_config.example` to `rcsm_config` and update the config to your needs
+The `redcraft-minecraft` image installs [rcsm](https://github.com/redcraft-org/redcraft_server_management) and you'll need to copy `rcsm_config.example` to `rcsm_config` and update the config to your needs.
+
+If you use the SSH version (`redcraft-minecraft-ssh.json`), you'll need to copy `openvpn_config.example` to `openvpn_config` to connect to your cloud provider private network. If you empty the file, OpenVPN setup will be skipped.
+
+You can setup a remote SSH server out of Scaleway with the following command: `SSH_HOST=<ip address> SSH_USERNAME=<username> SSH_PASSWORD=<password> packer build redcraft-minecraft-ssh.json`
 
 ## Add your user account
 

--- a/common/tasks/provision.sh
+++ b/common/tasks/provision.sh
@@ -13,7 +13,7 @@ add-apt-repository --yes https://adoptopenjdk.jfrog.io/adoptopenjdk/deb/
 apt-get update
 
 # Install packages
-apt-get install -y zip unzip htop python3 python3-venv python3-dev python3-pip tmux byobu git jq adoptopenjdk-8-hotspot dirmngr gnupg multitail tree iotop cowsay sl iftop dnsutils traceroute default-libmysqlclient-dev mariadb-client build-essential
+apt-get install -y sudo zip unzip htop python3 python3-venv python3-dev python3-pip tmux byobu git jq adoptopenjdk-8-hotspot dirmngr gnupg multitail tree iotop cowsay sl iftop dnsutils traceroute default-libmysqlclient-dev mariadb-client build-essential
 
 # Setup user accounts
 for user in /tmp/users/*.json; do
@@ -21,32 +21,41 @@ for user in /tmp/users/*.json; do
     hashed_password=$(cat $user | jq -r '.password_hash')
     ssh_public_key=$(cat $user | jq -r '.public_key')
 
-    useradd -m -p $hashed_password -s /bin/bash $username
-    mkdir -p /home/$username/.ssh
-    echo "$ssh_public_key" > /home/$username/.ssh/authorized_keys
-    chown -R $username:$username /home/$username/.ssh/
-    chmod 700 -R /home/$username/.ssh/
-    chmod 600 /home/$username/.ssh/authorized_keys
-    usermod -a -G sudo $username
-    if [[ -f "/tmp/users/$username.bashrc" ]]; then
-        cp "/tmp/users/$username.bashrc" /home/$username/.bashrc
-        chmod +x /home/$username/.bashrc
-        chown $username:$username /home/$username/.bashrc
+    # Check if user exists
+    if id -u $username > /dev/null 2>&1; then
+        echo "User $username already exists, skipping..."
+    else
+        useradd -m -p $hashed_password -s /bin/bash $username
+        mkdir -p /home/$username/.ssh
+        echo "$ssh_public_key" > /home/$username/.ssh/authorized_keys
+        chown -R $username:$username /home/$username/.ssh/
+        chmod 700 -R /home/$username/.ssh/
+        chmod 600 /home/$username/.ssh/authorized_keys
+        usermod -a -G sudo $username
+        if [[ -f "/tmp/users/$username.bashrc" ]]; then
+            cp "/tmp/users/$username.bashrc" /home/$username/.bashrc
+            chmod +x /home/$username/.bashrc
+            chown $username:$username /home/$username/.bashrc
+        fi
+        echo "Added user $username"
     fi
-    echo "Added user $username"
 done
 
 # Setup motd
-mv /tmp/motd.head /etc/motd.head
-sed -i '/Documentation:/d' /etc/update-motd.d/50-scw
-sed -i '/Community:/d' /etc/update-motd.d/50-scw
-sed -i '/Image source:/,+1 d' /etc/update-motd.d/50-scw
+if [[ -f "/etc/update-motd.d/50-scw" ]]; then
+    mv /tmp/motd.head /etc/motd.head
+    sed -i '/Documentation:/d' /etc/update-motd.d/50-scw
+    sed -i '/Community:/d' /etc/update-motd.d/50-scw
+    sed -i '/Image source:/,+1 d' /etc/update-motd.d/50-scw
+else
+    mv /tmp/motd.head /etc/motd
+fi
 
 # Remove SSH password authentication to enforce use of keys
 sed -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' /etc/ssh/sshd_config
 
 # Fix locale error
-touch /var/lib/cloud/instance/locale-check.skip
+touch /var/lib/cloud/instance/locale-check.skip || exit 0
 
 # Setup netdata
 apt-get install -y autoconf autoconf-archive autogen automake cmake gcc libelf-dev libjson-c-dev libjudy-dev liblz4-dev libmnl-dev libssl-dev libtool libuv1-dev pkg-config uuid-dev

--- a/images/redcraft-minecraft/.gitignore
+++ b/images/redcraft-minecraft/.gitignore
@@ -1,1 +1,2 @@
 *rcsm_config
+*openvpn_config

--- a/images/redcraft-minecraft/config/openvpn_config.example
+++ b/images/redcraft-minecraft/config/openvpn_config.example
@@ -1,0 +1,27 @@
+client
+dev tun
+dev-type tun
+remote REMOTE_IP REMOTE_PORT udp
+nobind
+persist-tun
+cipher AES-128-CBC
+auth SHA1
+push-peer-info
+ping 10
+ping-restart 60
+hand-window 70
+server-poll-timeout 5
+max-routes 1000
+remote-cert-tls server
+comp-lzo no
+key-direction 1
+<ca>
+-----BEGIN CERTIFICATE-----
+X509_CERTIFICATE
+-----END CERTIFICATE-----
+</cert>
+<key>
+-----BEGIN PRIVATE KEY-----
+PRIVATE_KEY
+-----END PRIVATE KEY-----
+</key>

--- a/images/redcraft-minecraft/redcraft-minecraft-ssh.json
+++ b/images/redcraft-minecraft/redcraft-minecraft-ssh.json
@@ -1,0 +1,65 @@
+{
+    "builders": [
+        {
+            "ssh_host": "{{ user `ssh_host` }}",
+            "ssh_username": "{{ user `ssh_username` }}",
+            "ssh_password": "{{ user `ssh_password` }}",
+            "type": "null"
+        }
+    ],
+    "provisioners": [
+        {
+            "destination": "/tmp/motd.head",
+            "source": "../../common/config/motd.head",
+            "type": "file"
+        },
+        {
+            "destination": "/tmp/users",
+            "source": "../../common/users",
+            "type": "file"
+        },
+        {
+            "destination": "/tmp/first_start_provisioning.sh",
+            "source": "../../common/tasks/first_start_provisioning.sh",
+            "type": "file"
+        },
+        {
+            "scripts": [
+                "../../common/tasks/provision.sh"
+            ],
+            "type": "shell"
+        },
+        {
+            "destination": "/tmp/rcsm.service",
+            "source": "config/rcsm.service",
+            "type": "file"
+        },
+        {
+            "destination": "/tmp/rcsm_config",
+            "source": "config/rcsm_config",
+            "type": "file"
+        },
+        {
+            "destination": "/tmp/openvpn_config",
+            "source": "config/openvpn_config",
+            "type": "file"
+        },
+        {
+            "scripts": [
+                "tasks/install_rcsm.sh"
+            ],
+            "type": "shell"
+        },
+        {
+            "scripts": [
+                "tasks/install_openvpn.sh"
+            ],
+            "type": "shell"
+        }
+    ],
+    "variables": {
+        "ssh_host": "{{ env `SSH_HOST` }}",
+        "ssh_username": "{{ env `SSH_USERNAME` }}",
+        "ssh_password": "{{ env `SSH_PASSWORD` }}"
+    }
+}

--- a/images/redcraft-minecraft/tasks/install_openvpn.sh
+++ b/images/redcraft-minecraft/tasks/install_openvpn.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Check if config file is empty or not
+if [ -s "/tmp/openvpn_config" ]
+then
+    # Install OpenVPN
+    apt-get install openvpn
+    sed -i 's/#AUTOSTART="all"/AUTOSTART="all"/g' /etc/default/openvpn
+    cp /tmp/openvpn_config /etc/openvpn/client.conf
+    systemctl enable openvpn@client.service
+    systemctl daemon-reload
+    systemctl start openvpn@client.service
+else
+	echo "No OpenVPN config found, setup skipped..."
+fi

--- a/images/redcraft-minecraft/tasks/install_rcsm.sh
+++ b/images/redcraft-minecraft/tasks/install_rcsm.sh
@@ -3,8 +3,12 @@
 set -e
 
 # Add minecraft user
-adduser --system --no-create-home --group minecraft
-mkdir /opt/rcsm
+if id -u minecraft > /dev/null 2>&1; then
+    echo "User minecraft already exists, using existing one"
+else
+    adduser --system --no-create-home --group minecraft
+fi
+mkdir -p /opt/rcsm
 chown -R minecraft:minecraft /opt/rcsm
 
 # Install rcsm


### PR DESCRIPTION
This PR allows us to install rcsm and OpenVPN on our Hetzner machine for game servers. I tested it on a fresh Debian install and it works.